### PR TITLE
toast.bodyOutputType default is ignored

### DIFF
--- a/toaster.js
+++ b/toaster.js
@@ -76,7 +76,9 @@ function ($compile, $timeout, $sce, toasterConfig, toaster) {
         
         id++;
         angular.extend(toast, { id: id });
-        
+
+	// Set the toast.bodyOutputType to the default if it isn't set
+	toast.bodyOutputType = toast.bodyOutputType || mergedConfig['body-output-type']
         switch(toast.bodyOutputType)
         {
           case 'trustedHtml':


### PR DESCRIPTION
Set the toast.bodyOutputType to the default if it isn't set
