### PR TITLE
add timeout to toaster event listeners in order to automatically trigger $apply method

### DIFF
--- a/toaster.js
+++ b/toaster.js
@@ -123,7 +123,10 @@ function ($compile, $timeout, $sce, toasterConfig, toaster) {
             });
 
             scope.$on('toaster-clearToasts', function () {
-                scope.toasters.splice(0, scope.toasters.length);
+                // wrap into timeout to trigger $apply method
+                $timeout(function(){
+                    scope.toasters.splice(0, scope.toasters.length);
+                });
             });
         },
         controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {


### PR DESCRIPTION
If you need to use toaster outside of a controllers you will need to trigger $appy() method to update scope.
For example you may want to write custom exception handler and show notifications on error.
