### PR TITLE
Fixed bug where not specifying 'toaster-options' caused an error.

### DIFF
--- a/toaster.js
+++ b/toaster.js
@@ -64,9 +64,7 @@ function ($compile, $timeout, $sce, toasterConfig, toaster) {
             var id = 0,
                 mergedConfig;
 
-            if (attrs.toasterOptions) {
-                mergedConfig = angular.extend({}, toasterConfig, scope.$eval(attrs.toasterOptions));
-            }
+            mergedConfig = angular.extend({}, toasterConfig, scope.$eval(attrs.toasterOptions));
 
             scope.config = {
                 position: mergedConfig['position-class'],
@@ -90,7 +88,7 @@ function ($compile, $timeout, $sce, toasterConfig, toaster) {
                 angular.extend(toast, { id: id });
 
                 // Set the toast.bodyOutputType to the default if it isn't set
-                toast.bodyOutputType = toast.bodyOutputType || mergedConfig['body-output-type']
+                toast.bodyOutputType = toast.bodyOutputType || mergedConfig['body-output-type'];
                 switch (toast.bodyOutputType) {
                     case 'trustedHtml':
                         toast.html = $sce.trustAsHtml(toast.body);


### PR DESCRIPTION
If `toaster-options` wasn't specified, `mergedConfig` was never assigned. This resulted in an error. Since the `$eval` function returns undefined if `attrs.toasterOptions` is undefined, we can simply remove the entire undefined check. This results in the toaster using default values.

We also added a missing semi-colon, for completeness :)
