### PR TITLE
change .pop arguments to parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ AngularJS-Toaster
 	angular.module('main', ['toaster'])
 	.controller('myController', function($scope, toaster) {
 	    $scope.pop = function(){
-	        toaster.pop('success', "title", "text");
+	        toaster.pop({
+                type: 'success', 
+                title: 'title', 
+                body: 'text'
+			});
 	    };
 	});
 ```

--- a/toaster.js
+++ b/toaster.js
@@ -15,14 +15,14 @@
 
 angular.module('toaster', ['ngAnimate'])
 .service('toaster', ['$rootScope', function ($rootScope) {
-    this.pop = function (type, title, body, timeout, bodyOutputType, clickHandler) {
+    this.pop = function (params) {
         this.toast = {
-            type: type,
-            title: title,
-            body: body,
-            timeout: timeout,
-            bodyOutputType: bodyOutputType,
-            clickHandler: clickHandler
+            type: params.type,
+            title: params.title,
+            body: params.body,
+            timeout: params.timeout,
+            bodyOutputType: params.bodyOutputType,
+            clickHandler: params.clickHandler
         };
         $rootScope.$broadcast('toaster-newToast');
     };


### PR DESCRIPTION
Hi there,

I've changed .pop() arguments to key/value format so it doesn't depend on the order of the arguments and therefore eliminating the need to add null or empty arguments. 

AngularStrap is doing something similar.
- Alex
