### PR TITLE
Fix invalid UTF-8 byte sequences in toaster.css

### DIFF
--- a/toaster.css
+++ b/toaster.css
@@ -1,12 +1,12 @@
 /*
  * Toastr
  * Version 2.0.1
- * Copyright 2012 John Papa and Hans Fj‰llemark.  
+ * Copyright 2012 John Papa and Hans Fj√§llemark.  
  * All Rights Reserved.  
  * Use, reproduction, distribution, and modification of this code is subject to the terms and 
  * conditions of the MIT license, available at http://www.opensource.org/licenses/mit-license.php
  *
- * Author: John Papa and Hans Fj‰llemark
+ * Author: John Papa and Hans Fj√§llemark
  * Project: https://github.com/CodeSeven/toastr
  */
 .toast-title {


### PR DESCRIPTION
toaster.css appears to be ISO-8859 encoded. This will choke some software/tools (in my case ruby/rails) that try to read this file.

Note that toaster.js also has the 'ä' character,  but it is encoded as UTF-8. This change standardizes the source files on the more common/flexible representation (UTF-8). 
