### PR TITLE
Allow toaster.clickHandler to be a callback function

### DIFF
--- a/toaster.js
+++ b/toaster.js
@@ -157,13 +157,19 @@ function ($compile, $timeout, $sce, toasterConfig, toaster) {
 
             $scope.click = function (toaster) {
                 if ($scope.config.tap === true) {
-                    if (toaster.clickHandler && angular.isFunction($scope.$parent.$eval(toaster.clickHandler))) {
-                        var result = $scope.$parent.$eval(toaster.clickHandler)(toaster);
-                        if (result === true)
-                            $scope.removeToast(toaster.id);
-                    } else {
-                        if (angular.isString(toaster.clickHandler))
+                    var removeToast = true;
+                    if (toaster.clickHandler) {
+                        if (angular.isFunction(toaster.clickHandler)) {
+                            removeToast = toaster.clickHandler(toaster);
+                        }
+                        else if (angular.isFunction($scope.$parent.$eval(toaster.clickHandler))) {
+                            removeToast = $scope.$parent.$eval(toaster.clickHandler)(toaster);
+                        }
+                        else {
                             console.log("TOAST-NOTE: Your click handler is not inside a parent scope of toaster-container.");
+                        }
+                    }
+                    if (removeToast) {
                         $scope.removeToast(toaster.id);
                     }
                 }


### PR DESCRIPTION
This PR allows to specify clickHandler as an anonymous funciton. Old functionality is left but it does not require to assign method to a scope anymore.

Before (still works):

```
toaster.pop('success', "title", 'Its address is https://google.com.', 15000, 'trustedHtml', 'goToLink');
$scope.goToLink = function(toaster) {
    var match = toaster.body.match(/http[s]?:\/\/[^\s]+/);
    if (match) $window.open(match[0]);
    return true;
};
```

After:

```
toaster.pop('success', "title", 'Its address is https://google.com.', 15000, 'trustedHtml', function(toaster) {
    var match = toaster.body.match(/http[s]?:\/\/[^\s]+/);
    if (match) $window.open(match[0]);
    return true;
});
```
