### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AngularJS-Toaster
 =================
 
-**AngularJS Toaster** is a AngularJS port of the **toastr** non-blocking notification jQuery library. It requires AngularJS v1.2.6 or higher and angular-animate for the CSS3 transformations. 
+**AngularJS Toaster** is an AngularJS port of the **toastr** non-blocking notification jQuery library. It requires AngularJS v1.2.6 or higher and angular-animate for the CSS3 transformations. 
 (I would suggest to use /1.2.8/angular-animate.js, there is a weird blinking in newer versions.)
 
 ### Current Version 0.4.9


### PR DESCRIPTION
'a Angular' -> 'an Angular'
