### PR TITLE
fix the issue with the pointer-events: none

### DIFF
--- a/toaster.css
+++ b/toaster.css
@@ -104,11 +104,18 @@ button.toast-close-button {
 #toast-container.toast-top-center,
 #toast-container.toast-bottom-center{
   width: 100%;
+  pointer-events: none;
 }
 #toast-container.toast-center > div,
 #toast-container.toast-top-center > div,
 #toast-container.toast-bottom-center > div{
   margin: auto;
+  pointer-events: auto;
+}
+#toast-container.toast-center > button,
+#toast-container.toast-top-cente > button,
+#toast-container.toast-bottom-center > button{
+  pointer-events: auto;
 }
 #toast-container * {
   -moz-box-sizing: border-box;


### PR DESCRIPTION
Regarding of the message I left on https://github.com/jirikavi/AngularJS-Toaster/commit/54c599fb878de39db2996d1cc2fd50aa2c6e2a56 

This way, we can still click on the elements behind the toaster when he's still displaying (when his positionned on the top-center, bottom-center or center).
