### PR TITLE
Adding posibility to send arbitrary data to templates.

### DIFF
--- a/toaster.js
+++ b/toaster.js
@@ -123,7 +123,8 @@ function ($compile, $rootScope, $interval, $sce, toasterConfig, toaster) {
                         toast.html = $sce.trustAsHtml(toast.body);
                         break;
                     case 'template':
-                        toast.bodyTemplate = toast.body || mergedConfig['body-template'];
+                        toast.bodyTemplate = toast.body.template || toast.body || mergedConfig['body-template'];
+                        toast.data = toast.body.data || undefined;
                         break;
                 }
 


### PR DESCRIPTION
There is currently no way to send arbitrary data to the templates used in the toasts. The only current use of templates right now is for static data.
I really need a way to send custom data to the templates from the place that first initiate the toast.

This fix makes that possible without breaking anything.