### PR TITLE
Fix to reset state when directive is destroyed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-Toaster",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": [
     "toaster.js",
     "toaster.css"

--- a/toaster.js
+++ b/toaster.js
@@ -93,6 +93,12 @@ angular.module('toaster', ['ngAnimate'])
       registerClearAllToastsEvent: function(){
         this._ClearAllToastsEvent = true;
       },
+      deregisterNewToastEvent: function(){
+        this._NewToastEvent = false;
+      },
+      deregisterClearAllToastsEvent: function(){
+        this._ClearAllToastsEvent = false;
+      },
       isRegisteredNewToastEvent: function(){
         return this._NewToastEvent;
       },
@@ -103,6 +109,8 @@ angular.module('toaster', ['ngAnimate'])
     return {
       registerNewToastEvent: toasterFactory.registerNewToastEvent,
       registerClearAllToastsEvent: toasterFactory.registerClearAllToastsEvent,
+		deregisterNewToastEvent: toasterFactory.deregisterNewToastEvent,
+		deregisterClearAllToastsEvent: toasterFactory.deregisterClearAllToastsEvent,
       isRegisteredNewToastEvent: toasterFactory.isRegisteredNewToastEvent,
       isRegisteredClearAllToastsEvent: toasterFactory.isRegisteredClearAllToastsEvent
   }
@@ -114,7 +122,6 @@ function ($parse, $rootScope, $interval, $sce, toasterConfig, toaster, toasterRe
         restrict: 'EA',
         scope: true, // creates an internal scope for this directive
         link: function (scope, elm, attrs) {
-
             var id = 0,
                 mergedConfig;
 
@@ -138,6 +145,8 @@ function ($parse, $rootScope, $interval, $sce, toasterConfig, toaster, toasterRe
                 if (scope.deregNewToast) scope.deregNewToast();
                 scope.deregClearToasts=null;
                 scope.deregNewToast=null;
+				toasterRegisterEvents.deregisterNewToastEvent();
+				toasterRegisterEvents.deregisterClearAllToastsEvent();
             });
 
             scope.configureTimer = function configureTimer(toast) {

--- a/toaster.js
+++ b/toaster.js
@@ -109,8 +109,8 @@ angular.module('toaster', ['ngAnimate'])
     return {
       registerNewToastEvent: toasterFactory.registerNewToastEvent,
       registerClearAllToastsEvent: toasterFactory.registerClearAllToastsEvent,
-		deregisterNewToastEvent: toasterFactory.deregisterNewToastEvent,
-		deregisterClearAllToastsEvent: toasterFactory.deregisterClearAllToastsEvent,
+      deregisterNewToastEvent: toasterFactory.deregisterNewToastEvent,
+      deregisterClearAllToastsEvent: toasterFactory.deregisterClearAllToastsEvent,
       isRegisteredNewToastEvent: toasterFactory.isRegisteredNewToastEvent,
       isRegisteredClearAllToastsEvent: toasterFactory.isRegisteredClearAllToastsEvent
   }
@@ -145,8 +145,8 @@ function ($parse, $rootScope, $interval, $sce, toasterConfig, toaster, toasterRe
                 if (scope.deregNewToast) scope.deregNewToast();
                 scope.deregClearToasts=null;
                 scope.deregNewToast=null;
-				toasterRegisterEvents.deregisterNewToastEvent();
-				toasterRegisterEvents.deregisterClearAllToastsEvent();
+                toasterRegisterEvents.deregisterNewToastEvent();
+                toasterRegisterEvents.deregisterClearAllToastsEvent();
             });
 
             scope.configureTimer = function configureTimer(toast) {


### PR DESCRIPTION
When (for example) the toaster directive is destroyed by switching out `ui-view`s using `ui-router`, the internal variables for the `toasterRegisterEvents` are not reset. The next time the directive is created (by coming back to the first view), the state of the factory object prevents watchers from being created. 

This fixes that by resetting the state of the variables for the `toasterRegisterEvents` factory, which allows the link function to properly function and recreate state.