### PR TITLE
created a separate data parameter for assignment if the directive is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ There are four types of body renderings: trustedHtml', 'template', 'templateWith
 	If the html can be successfully parsed, it will be bound to the toast via `ng-bind-html`.  If it cannot be parsed as "trustable" html, an exception will be thrown.	
 
  - template:  Will use the `toast.body` if passed as an argument, else it will fallback to the template bound to the `'body-template': 'toasterBodyTmpl.html'` configuration option.
+	 - Any data passed in by type or the data param will be assgined to the toast.data property for binding.
  
  - templateWithData: 
 	 - Will use the `toast.body` if passed as an argument, else it will fallback to the template bound to the `'body-template': 'toasterBodyTmpl.html'` configuration option.
-	 - Assigns any data associated with the template to the toast.
+	 - Assigns any data associated with the template to the toast. Template data will override the data param.
+	 
 
  - directive 
 	 - Will use the `toast.body` argument to represent the name of a directive that you want to render as the toast's body, else it will fallback to the template bound to the `'body-template': 'toasterBodyTmpl.html'` configuration option.

--- a/toaster.js
+++ b/toaster.js
@@ -58,7 +58,7 @@
         ).service(
         'toaster', [
             '$rootScope', 'toasterConfig', function ($rootScope, toasterConfig) {
-                this.pop = function (type, title, body, timeout, bodyOutputType, clickHandler, toasterId, showCloseButton, toastId, onHideCallback) {
+                this.pop = function (type, title, body, timeout, bodyOutputType, clickHandler, toasterId, showCloseButton, toastId, onHideCallback, data) {
                     if (angular.isObject(type)) {
                         var params = type; // Enable named parameters as pop argument
                         this.toast = {
@@ -70,7 +70,8 @@
                             clickHandler: params.clickHandler,
                             showCloseButton: params.showCloseButton,
                             uid: params.toastId,
-                            onHideCallback: params.onHideCallback
+                            onHideCallback: params.onHideCallback,
+							data: params.data
                         };
                         toastId = params.toastId;
                         toasterId = params.toasterId;
@@ -84,7 +85,8 @@
                             clickHandler: clickHandler,
                             showCloseButton: showCloseButton,
                             uid: toastId,
-                            onHideCallback: onHideCallback
+                            onHideCallback: onHideCallback,
+							dataObject: data
                         };
                     }
                     $rootScope.$emit('toaster-newToast', toasterId, toastId);

--- a/toaster.js
+++ b/toaster.js
@@ -71,7 +71,7 @@
                             showCloseButton: params.showCloseButton,
                             uid: params.toastId,
                             onHideCallback: params.onHideCallback,
-							data: params.data
+			    data: params.data
                         };
                         toastId = params.toastId;
                         toasterId = params.toasterId;
@@ -86,7 +86,7 @@
                             showCloseButton: showCloseButton,
                             uid: toastId,
                             onHideCallback: onHideCallback,
-							dataObject: data
+			    data: data
                         };
                     }
                     $rootScope.$emit('toaster-newToast', toasterId, toastId);


### PR DESCRIPTION
…not on the scope of the caller.

If the directive is not on the same scope as the caller, the binding in a template won't work. Also because the template data is passed in as a string pointer to the scope object, that doesn't work either. 

I ran into an issue where the directive itself is on the index.html page in order to be consistent on all pages. I wanted to pass into the data property of the toast itself an object local to the scope of the page from it's controller but because the data parameter is a string and get's run on the scope of the directive, it won't bind. By adding the data as a parameter that get's set on the toast itself when you call pop, it's much easier to set it and the api is the same to bind to it in the template.
ie.

function raiseToastForLocalSave(locale)
{
var toasterPopup = toaster.pop({
                    type: 'info',
                    title: $filter('translate')('TAB_CONFIG_LOCALES_CHANGES_SAVED'),
                    body: "toasterTemplate.html",
                    timeout: 4000,
                    bodyOutputType: 'template',
                    data: locale
                });
}

locale is a local object that I want on the data property of the toast and then I can bind to it for things like adding an undo button like this.

<script type="text/ng-template" id="toasterTemplate.html">
                {{toaster.data.name}}
        <a ng-if="toaster.data.isUndoMode" href="" class="btn btn-danger btn-xs pull-right" ng-click="localeConfig.undoLocale(toaster.data)">{{'UNDO' | translate}}</a>
    </script>