### PR TITLE
Bumped version to 1.1.0 instead of 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AngularJS-Toaster
 [![Build Status](https://travis-ci.org/jirikavi/AngularJS-Toaster.svg)](https://travis-ci.org/jirikavi/AngularJS-Toaster)
 [![Coverage Status](https://coveralls.io/repos/jirikavi/AngularJS-Toaster/badge.svg?branch=master&service=github&busted=1)](https://coveralls.io/github/jirikavi/AngularJS-Toaster?branch=master)
 
-### Current Version 1.0.1
+### Current Version 1.1.0
 
 ## Demo
 - Simple demo is at http://plnkr.co/edit/HKTC1a
@@ -28,10 +28,10 @@ npm install --save angularjs-toaster
 * Link scripts:
 
 ```html
-<link href="https://cdnjs.cloudflare.com/ajax/libs/angularjs-toaster/1.0.1/toaster.min.css" rel="stylesheet" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/angularjs-toaster/1.1.0/toaster.min.css" rel="stylesheet" />
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.min.js" ></script>
 <script src="https://code.angularjs.org/1.2.0/angular-animate.min.js" ></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/angularjs-toaster/1.0.1/toaster.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/angularjs-toaster/1.1.0/toaster.min.js"></script>
 ```
 
 * Add toaster container directive: 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-Toaster",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": [
     "toaster.js",
     "toaster.css"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-toaster",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "AngularJS Toaster is a customized version of toastr non-blocking notification javascript library",
   "author": "Jiri Kavulak",
   "license": "MIT",

--- a/toaster.js
+++ b/toaster.js
@@ -4,7 +4,7 @@
 
     /*
      * AngularJS Toaster
-     * Version: 1.0.1
+     * Version: 1.1.0
      *
      * Copyright 2013-2016 Jiri Kavulak.
      * All Rights Reserved.

--- a/toaster.min.js
+++ b/toaster.min.js
@@ -1,6 +1,6 @@
 /*
  * AngularJS Toaster
- * Version: 1.0.1
+ * Version: 1.1.0
  *
  * Copyright 2013-2016 Jiri Kavulak.
  * All Rights Reserved.


### PR DESCRIPTION
Since this was a backwards-compatible feature release, in keeping with
Semantic Versioning this would have been bumped to 1.1.0 instead of
1.0.1.  Updated versions.