### PR TITLE
Fix for wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "main": [
     "toaster.js",
-    "toaster.css"
+    "toaster.css",
+    "toaster.scss"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Hello,
a quick fix for wiredep builds: without `toaster.scss`, the dependency will not be automatically picked up by wiredep