### PR TITLE
add missing package.main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angularjs-toaster",
   "version": "2.1.0",
+  "main": "toaster.js",
   "description": "AngularJS Toaster is a customized version of toastr non-blocking notification javascript library",
   "author": "Jiri Kavulak",
   "license": "MIT",


### PR DESCRIPTION
Importing through npm system and using browserify fails without this as the entry point does not match those checked by node [here](https://nodejs.org/api/modules.html#modules_folders_as_modules) and so needs to be provided manually.