### PR TITLE
Match package.json version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-Toaster",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": [
     "toaster.js",
     "toaster.css",


### PR DESCRIPTION
There's a warning when installing : `bower angularjs-toaster#*     mismatch Version declared in the json (2.0.0) is different than the resolved one (2.1.0)`

Thanks for the lib!
