### PR TITLE
onHideCallback is now called when a toast is removed by the limit

### DIFF
--- a/test/toasterContainerSpec.js
+++ b/test/toasterContainerSpec.js
@@ -511,6 +511,41 @@ describe('toasterContainer', function () {
 			
 			expect(toastSetByCallback).not.toBeNull();
 		});
+
+		it('should invoke onHideCallback if toast is removed by limit', function () {
+			var container = angular.element(
+				'<toaster-container toaster-options="{\'limit\': 2, \'newest-on-top\': true }"></toaster-container>');
+				
+			$compile(container)(rootScope);
+			rootScope.$digest();
+			
+			var scope = container.scope();
+
+			var mock = {
+				callback : function () { }
+			};
+			
+			spyOn(mock, 'callback');
+			
+			toaster.pop({ type: 'info', body: 'first', onHideCallback: mock.callback });
+			toaster.pop({ type: 'info', body: 'second' });
+			
+			rootScope.$digest();
+			
+			expect(scope.toasters.length).toBe(2);
+			expect(scope.toasters[0].body).toBe('second');
+			expect(scope.toasters[1].body).toBe('first');
+			
+			toaster.pop({ type: 'info', body: 'third' });
+			
+			rootScope.$digest();
+			
+			expect(scope.toasters.length).toBe(2);
+			expect(scope.toasters[0].body).toBe('third');
+			expect(scope.toasters[1].body).toBe('second');
+
+			expect(mock.callback).toHaveBeenCalled();
+		});
 	});
 
 

--- a/toaster.js
+++ b/toaster.js
@@ -386,12 +386,12 @@
                             if (mergedConfig['newest-on-top'] === true) {
                                 scope.toasters.unshift(toast);
                                 if (mergedConfig['limit'] > 0 && scope.toasters.length > mergedConfig['limit']) {
-                                    scope.toasters.pop();
+                                    removeToast(scope.toasters.length - 1);
                                 }
                             } else {
                                 scope.toasters.push(toast);
                                 if (mergedConfig['limit'] > 0 && scope.toasters.length > mergedConfig['limit']) {
-                                    scope.toasters.shift();
+                                    removeToast(0);
                                 }
                             }
 


### PR DESCRIPTION
Currently, when the `limit` threshold is reached, old toasts are silently removed (without calling their `onHideCallback()`). This pull request fixes this oversight by removing toasts using the `removeToast()` function which triggers the callback.