### PR TITLE
Update version to 3.0.0 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-Toaster",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "main": [
     "toaster.js",
     "toaster.css",


### PR DESCRIPTION
This is to keep the bower metadata in sync with the rest of the repository after the update to 3.0.0

I'm getting the following error when trying to install via bower:

> bower angularjs-toaster#3.0.0 mismatch Version declared in the json (2.2.0) is different than the resolved one (3.0.0)

I think we'll need this change and probably a lable update to resolve.

I hope just opening a PR is appropriate. Please let me know if you have any questions.